### PR TITLE
Fix uv creating implicit venv by targeting Blender environment

### DIFF
--- a/env/Activate.ps1
+++ b/env/Activate.ps1
@@ -53,6 +53,7 @@ if (-not (Test-Path variable:SISIFOS_OLD_PROMPT)) {
 $env:PATH = "$BlenderPythonDir;$BlenderDir;$env:PATH"
 $env:BLENDER = $BlenderExe
 $env:PYTHON = $BlenderPython
+$env:UV_PROJECT_ENVIRONMENT = Split-Path -Path $BlenderPythonDir -Parent
 
 # 2. Modify Prompt
 if (Test-Path variable:Global:__VSCodeState) {
@@ -84,6 +85,7 @@ function global:deactivate {
         Remove-Item env:\SISIFOS_OLD_PATH -ErrorAction SilentlyContinue
         Remove-Item env:\BLENDER -ErrorAction SilentlyContinue
         Remove-Item env:\PYTHON -ErrorAction SilentlyContinue
+        Remove-Item env:\UV_PROJECT_ENVIRONMENT -ErrorAction SilentlyContinue
         Remove-Item function:deactivate -ErrorAction SilentlyContinue
         Write-Host "[SISIFOS] Environment deactivated." -ForegroundColor Yellow
     }

--- a/env/Setup.ps1
+++ b/env/Setup.ps1
@@ -56,6 +56,7 @@ try {
 
     # 4. Setup Python Environment
     Push-Location $ProjectRoot
+    $env:UV_PROJECT_ENVIRONMENT = Split-Path -Path $BlenderPythonDir -Parent
 
     Update-Progress "Bootstrapping pip..."
     & $BlenderPython -m ensurepip --upgrade *>$null
@@ -82,6 +83,7 @@ try {
     & $BlenderPython -m uv pip install --no-deps --editable . -q *>$null
     if ($LASTEXITCODE -ne 0) { throw "editable install failed" }
     
+    Remove-Item env:\UV_PROJECT_ENVIRONMENT -ErrorAction SilentlyContinue
     Pop-Location
 
     # Clear progress

--- a/env/activate.sh
+++ b/env/activate.sh
@@ -83,6 +83,7 @@ export SISIFOS_OLD_PS1="$PS1"
 export PATH="$BLENDER_PYTHON_BIN_DIR:$BLENDER_DIR:$PATH"
 export BLENDER="$BLENDER_EXE"
 export PYTHON="$BLENDER_PYTHON"
+export UV_PROJECT_ENVIRONMENT="$(dirname "$BLENDER_PYTHON_BIN_DIR")"
 
 # Update Prompt
 PS1="[SISIFOS] $PS1"
@@ -97,6 +98,7 @@ deactivate() {
         unset SISIFOS_OLD_PS1
         unset BLENDER
         unset PYTHON
+        unset UV_PROJECT_ENVIRONMENT
         unset -f deactivate
         
         echo -e "\033[0;33m[SISIFOS] Environment deactivated.\033[0m"

--- a/env/setup.sh
+++ b/env/setup.sh
@@ -147,6 +147,7 @@ fi
 # 4. Generate lock file
 update_progress "Generating lock file..."
 cd "$PROJECT_ROOT" || cleanup_and_exit "Failed to change to $PROJECT_ROOT"
+export UV_PROJECT_ENVIRONMENT="$(dirname "$BLENDER_PYTHON_BIN_DIR")"
 if ! "$BLENDER_PYTHON" -m uv lock -q >/dev/null 2>&1; then
     cleanup_and_exit "uv lock failed"
     return
@@ -175,6 +176,7 @@ if ! "$BLENDER_PYTHON" -m uv pip install --no-deps --editable . -q >/dev/null 2>
 fi
 
 # Success
+unset UV_PROJECT_ENVIRONMENT
 printf "\r%-60s\r" " "
 echo -e "${GREEN}SISIFOS Setup complete.${NC}"
 echo "Run 'source ./env/activate.sh' to start."


### PR DESCRIPTION
### Summary
This PR fixes a bug where `uv add` and `uv sync` commands were failing to install packages into the SISIFOS environment (Blender's bundled Python). Instead, `uv` was implicitly creating and installing packages into a standard `.venv` directory in the project root, ignoring the currently active Blender environment.

### The Fix
Explicitly sets the `UV_PROJECT_ENVIRONMENT` environment variable in all setup and activation scripts (`Activate.ps1`, `activate.sh`, `Setup.ps1`, `setup.sh`). This variable tells `uv` to target the Blender-bundled Python environment root instead of looking for or creating a default virtual environment.

### Changes
- **Windows (`Activate.ps1`, `Setup.ps1`)**:  
  Added `$env:UV_PROJECT_ENVIRONMENT` pointing to the parent directory of the Blender Python binary.  
- **Mac/Linux (`activate.sh`, `setup.sh`)**:  
  Added `export UV_PROJECT_ENVIRONMENT` pointing to the parent directory of the Blender Python binary.  

### Verification
- Deleted any existing `.venv` folder.
- Ran `Setup.ps1` (or `source env/setup.sh`).
- Activated environment.
- Ran `uv add <package>` → Verified package is available in Blender Python and no `.venv` folder is created.
