### PR TITLE
Scene graph toggle and subsample/cap

### DIFF
--- a/configs/test_integral.json
+++ b/configs/test_integral.json
@@ -104,6 +104,7 @@
     "save_segmentation": false,
     "save_obj_poses": false,
     "save_scene_plots": false,
+    "scene_plot_max_frames": 100,
     "frame_ids": null,
     "selected_model": "RF_Integral",
     "model_rotation_z_deg": 45.0

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ def generate_trajectories(config: SceneConfig, output_dir: Path, config_prefix: 
             model_name=model_token,
             camera_config=config.camera,
             save_scene_plots=config.save_scene_plots,
+            scene_plot_max_frames=config.scene_plot_max_frames,
         )
 
     elif config.trajectory_type == "sampling_trajectory":

--- a/modules/ConfigInfo.md
+++ b/modules/ConfigInfo.md
@@ -104,6 +104,10 @@ bool option to save object poses
 #### save_scene_plots
 bool option to save trajectory scene graphs
 
+#### scene_plot_max_frames
+int or null controlling the maximum number of scene-plot frames generated when `save_scene_plots` is true.
+Set to `null` to remove the cap.
+
 #### frame_ids
 list of ints for what to render
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -198,6 +198,7 @@ class SceneConfig(BaseModel):
     save_segmentation: bool = True
     save_obj_poses: bool = True
     save_scene_plots: bool = True
+    scene_plot_max_frames: int | None = Field(default=100, ge=1)
 
     # Rendering control
     frame_ids: list[int] | None = None  # If None, use all frames

--- a/modules/trajectory/generateTrajectoriesUnified.py
+++ b/modules/trajectory/generateTrajectoriesUnified.py
@@ -101,6 +101,7 @@ def generate_trajectories_dynamical(
     model_name: str = "",
     camera_config: CameraConfig = None,
     save_scene_plots: bool = True,
+    scene_plot_max_frames: int | None = 100,
 ) -> list[str]:
     if camera_config is None:
         camera_config = CameraConfig()
@@ -786,6 +787,7 @@ def generate_trajectories_dynamical(
                     r_CG_arr=r_CG_G_mc_ag,
                     q_IG_arr=q_IG_mc,
                     q_IC_arr=q_IC_mc_ag,
+                    max_frames=scene_plot_max_frames,
                 )
 
     logger.info("[DONE] Output written to: %s", base_output_file)

--- a/modules/trajectory/plot_figure.py
+++ b/modules/trajectory/plot_figure.py
@@ -735,7 +735,7 @@ def generate_scene_plots(
     q_IG_arr: np.ndarray,
     q_IC_arr: np.ndarray,
     every_n_frames=1,
-    max_frames=None,
+    max_frames=100,
 ):
     """
     Generate two plot sets for multiple frames in the INERTIAL FRAME:
@@ -772,7 +772,7 @@ def generate_scene_plots(
     every_n_frames : int
         Generate plot every N frames (1 = every frame)
     max_frames : int or None
-        Maximum number of frames to process
+        Maximum number of frames to process (uniformly subsampled across the trajectory)
     """
     n_frames = min(
         len(p_C_I),
@@ -785,12 +785,25 @@ def generate_scene_plots(
         len(q_IC_arr),
     )
 
-    if max_frames is not None:
-        n_frames = min(n_frames, max_frames)
     if n_frames <= 0:
         raise ValueError("No frames available to plot scene figures.")
     if every_n_frames <= 0:
         raise ValueError("every_n_frames must be >= 1.")
+
+    frame_step = max(1, int(every_n_frames))
+    if max_frames is not None and n_frames > max_frames:
+        frame_step = max(frame_step, n_frames // int(max_frames))
+    frames_to_process = list(range(0, n_frames, frame_step))
+
+    if max_frames is not None and n_frames > max_frames:
+        logger.info(
+            "Processing %d frames (every %d frames) out of %d total.",
+            len(frames_to_process),
+            frame_step,
+            n_frames,
+        )
+    else:
+        logger.info("Processing all %d frames.", n_frames)
 
     # Compute STATIC sun direction in inertial frame from frame 0
     az0_rad = np.radians(sun_az_I[0])
@@ -818,7 +831,7 @@ def generate_scene_plots(
     rendered_scene_frames = []
     rendered_pose_frames = []
     rendered_indices = []
-    for i in range(0, n_frames, every_n_frames):
+    for processed_idx, i in enumerate(frames_to_process, start=1):
         # Get rotation from Inertial to Body frame at this timestep
         qw, qx, qy, qz = q_IG_arr[i]
         rot_IG = Rotation.from_quat([qx, qy, qz, qw])
@@ -862,8 +875,14 @@ def generate_scene_plots(
         rendered_pose_frames.append(pose_rgb)
         rendered_indices.append(i)
 
-        if i % 50 == 0:
-            logger.info("  Generated scene plot for frame %d/%d", i, n_frames)
+        if processed_idx == 1 or processed_idx % 50 == 0 or processed_idx == len(frames_to_process):
+            logger.info(
+                "  Generated scene plot %d/%d (frame %d of %d)",
+                processed_idx,
+                len(frames_to_process),
+                i,
+                n_frames,
+            )
 
     scene_video = _save_animation_from_frames(
         rendered_frames=rendered_scene_frames,


### PR DESCRIPTION
Added params in the config file to turn off scene graphs and to cap the amount that are saved, cutting down on computation for long trajectories